### PR TITLE
Develop 03 06 2018

### DIFF
--- a/oap2dt3dDevice/DeviceDataLoader.cpp
+++ b/oap2dt3dDevice/DeviceDataLoader.cpp
@@ -41,10 +41,26 @@ math::Matrix* DeviceDataLoader::createDeviceRowVector(size_t index) {
   return device;
 }
 
+math::Matrix* DeviceDataLoader::getDeviceRowVector(size_t index, math::Matrix* dmatrix)
+{
+  math::Matrix* host = createRowVector(index);
+  oap::cuda::CopyHostMatrixToDeviceMatrix(dmatrix, host);
+  oap::host::DeleteMatrix(host);
+  return dmatrix;
+}
+
 math::Matrix* DeviceDataLoader::createDeviceColumnVector(size_t index) {
   math::Matrix* host = createColumnVector(index);
   math::Matrix* device = oap::cuda::NewDeviceMatrixCopy(host);
   oap::host::DeleteMatrix(host);
   return device;
+}
+
+math::Matrix* DeviceDataLoader::getDeviceColumnVector(size_t index, math::Matrix* dmatrix)
+{
+  math::Matrix* host = createColumnVector(index);
+  oap::cuda::CopyHostMatrixToDeviceMatrix(dmatrix, host);
+  oap::host::DeleteMatrix(host);
+  return dmatrix;
 }
 }

--- a/oap2dt3dDevice/DeviceDataLoader.h
+++ b/oap2dt3dDevice/DeviceDataLoader.h
@@ -38,7 +38,10 @@ class DeviceDataLoader : public DataLoader {
   math::Matrix* createDeviceMatrix();
 
   math::Matrix* createDeviceRowVector(size_t index);
+  math::Matrix* getDeviceRowVector(size_t index, math::Matrix* dmatrix);
+
   math::Matrix* createDeviceColumnVector(size_t index);
+  math::Matrix* getDeviceColumnVector(size_t index, math::Matrix* dmatrix);
 };
 }
 

--- a/oap2dt3dDevice/MainAPExecutor.h
+++ b/oap2dt3dDevice/MainAPExecutor.h
@@ -31,7 +31,8 @@ class MainAPExecutor
     class EigenCalculator;
     MainAPExecutor(CuHArnoldiCallback* cuhArnolldi, bool deallocateArnoldi);
 
-    static void multiplyCallback(math::Matrix* m_w, math::Matrix* m_v, oap::CuProceduresApi& cuProceduresApi, void* userData, CuHArnoldi::MultiplicationType mt);
+    static void multiplyMatrixCallback(math::Matrix* m_w, math::Matrix* m_v, oap::CuProceduresApi& cuProceduresApi, void* userData, CuHArnoldi::MultiplicationType mt);
+    static void multiplyVecsCallback(math::Matrix* m_w, math::Matrix* m_v, oap::CuProceduresApi& cuProceduresApi, void* userData, CuHArnoldi::MultiplicationType mt);
 
     EigenCalculator* m_eigenCalc;
     CuHArnoldiCallback* m_cuhArnoldi;


### PR DESCRIPTION
 Commit "MainAPExecutor: two variants of multipy callbacks: multiplyMatrixCall… " contains fix for invalid eigenvector (root cause: iteration over columns, not rows)